### PR TITLE
Fix agumented assignment methods

### DIFF
--- a/padme/__init__.py
+++ b/padme/__init__.py
@@ -227,9 +227,12 @@ class proxy_meta(type):
         ns['__unproxied__'] = frozenset(unproxied_set)
         # _logger.debug("injecting fresh _c_registry into %s", name)
         ns['_c_registry'] = {}
-        return super(proxy_meta, mcls).__new__(mcls, name, bases, ns)
+        cls = super(proxy_meta, mcls).__new__(mcls, name, bases, ns)
+        cls._untyped_base = cls
+        return cls
 
     def __getitem__(proxy_cls, proxiee_cls):
+        proxy_cls = proxy_cls._untyped_base
         if not isinstance(proxiee_cls, type):
             raise ValueError("proxiee_cls must be a type")
         if proxiee_cls not in proxy_cls._m_registry:
@@ -244,6 +247,7 @@ class proxy_meta(type):
             proxy_cls._c_registry[proxiee_cls] = typed_proxy_cls
         else:
             typed_proxy_cls = proxy_cls._c_registry[proxiee_cls]
+        typed_proxy_cls._untyped_base = proxy_cls
         return typed_proxy_cls
 
 

--- a/padme/__init__.py
+++ b/padme/__init__.py
@@ -356,8 +356,9 @@ def _imethod(self, other, name, op):
         # the __iFUNC__ method returns something other than self. To maintain
         # the illusion that the proxy is not there the internal proxiee
         # reference is changed to the new proxiee.
-        _logger.debug("%s sets new proxiee (%r)", name, proxiee_new)
-        _set_proxiee(self, proxiee_new)
+        _logger.debug("%s creates new %s (%r)",
+                      name, type(self).__name__, proxiee_new)
+        return type(self)(proxiee_new)
     return self
 
 

--- a/padme/tests.py
+++ b/padme/tests.py
@@ -708,6 +708,115 @@ class proxy_as_function(unittest.TestCase):
         self.assertTrue(issubclass(type(b), proxy))
         self.assertIs(a, b)
 
+    def test_isub__on_int(self):
+        """ Verify that -= works on proxy[int]. """
+        a = b = proxy(4)
+        b -= 3
+        self.assertEqual(a, 4)
+        self.assertEqual(b, 1)
+        self.assertTrue(issubclass(type(a), proxy))
+        self.assertTrue(issubclass(type(b), proxy))
+
+    def test_imul__on_int(self):
+        """ Verify that *= works on proxy[int]. """
+        a = b = proxy(4)
+        b *= 2
+        self.assertEqual(a, 4)
+        self.assertEqual(b, 8)
+        self.assertTrue(issubclass(type(a), proxy))
+        self.assertTrue(issubclass(type(b), proxy))
+
+    @unittest.skipUnless(sys.version_info[0] == 2, "requires python 2")
+    def test_idiv__on_int(self):
+        """ Verify that (old) /= works on proxy[int]. """
+        a = b = proxy(7)
+        b = operator.idiv(b, 2)
+        self.assertEqual(a, 7)
+        self.assertEqual(b, 3)
+        self.assertTrue(issubclass(type(a), proxy))
+        self.assertTrue(issubclass(type(b), proxy))
+
+    def test_itruediv__on_int(self):
+        """ Verify that (true) /= works on proxy[int]. """
+        a = b = proxy(7)
+        b = operator.itruediv(b, 2)
+        self.assertEqual(a, 7)
+        self.assertEqual(b, 3.5)
+        self.assertTrue(issubclass(type(a), proxy))
+        self.assertTrue(issubclass(type(b), proxy))
+
+    def test_ifloordiv__on_int(self):
+        """ Verify that //= works on proxy[int]. """
+        a = b = proxy(7)
+        b //= 2
+        self.assertEqual(a, 7)
+        self.assertEqual(b, 3)
+        self.assertTrue(issubclass(type(a), proxy))
+        self.assertTrue(issubclass(type(b), proxy))
+
+    def test_imod__on_int(self):
+        """ Verify that %= works on proxy[int]. """
+        a = b = proxy(7)
+        b %= 2
+        self.assertEqual(a, 7)
+        self.assertEqual(b, 1)
+        self.assertTrue(issubclass(type(a), proxy))
+        self.assertTrue(issubclass(type(b), proxy))
+
+    def test_ipow__on_int(self):
+        """ Verify that **= works on proxy[int]. """
+        a = b = proxy(7)
+        b **= 2
+        self.assertEqual(a, 7)
+        self.assertEqual(b, 49)
+        self.assertTrue(issubclass(type(a), proxy))
+        self.assertTrue(issubclass(type(b), proxy))
+
+    def test_ilshift__on_int(self):
+        """ Verify that <<= works on proxy[int]. """
+        a = b = proxy(1)
+        b <<= 10
+        self.assertEqual(a, 1)
+        self.assertEqual(b, 1024)
+        self.assertTrue(issubclass(type(a), proxy))
+        self.assertTrue(issubclass(type(b), proxy))
+
+    def test_irshift__on_int(self):
+        """ Verify that >>= works on proxy[int]. """
+        a = b = proxy(1024)
+        b >>= 10
+        self.assertEqual(a, 1024)
+        self.assertEqual(b, 1)
+        self.assertTrue(issubclass(type(a), proxy))
+        self.assertTrue(issubclass(type(b), proxy))
+
+    def test_iand__on_int(self):
+        """ Verify that &= works on proxy[int]. """
+        a = b = proxy(7)
+        b &= 4
+        self.assertEqual(a, 7)
+        self.assertEqual(b, 4)
+        self.assertTrue(issubclass(type(a), proxy))
+        self.assertTrue(issubclass(type(b), proxy))
+
+    def test_ixor__on_int(self):
+        """ Verify that ^= works on proxy[int]. """
+        a = b = proxy(7)
+        b ^= 5
+        self.assertEqual(a, 7)
+        self.assertEqual(b, 2)
+        self.assertTrue(issubclass(type(a), proxy))
+        self.assertTrue(issubclass(type(b), proxy))
+
+    def test_ior__on_int(self):
+        """ Verify that |= works on proxy[int]. """
+        a = b = proxy(7)
+        b |= 8
+        self.assertEqual(a, 7)
+        self.assertEqual(b, 15)
+        self.assertTrue(issubclass(type(a), proxy))
+        self.assertTrue(issubclass(type(b), proxy))
+
     def test_context_manager_methods_v1(self):
         """ Verify that __enter__ and __exit__ are redirected. """
         with self.proxy:


### PR DESCRIPTION
This branch fixes all of the augmented assignment methods not to change the proxied object but instead return a new proxy instance if the augmented assignment operation on the original value returns a distinct new object.
